### PR TITLE
Allowing this weeks events to be triggered manually

### DIFF
--- a/.github/workflows/this-weeks-events.yml
+++ b/.github/workflows/this-weeks-events.yml
@@ -1,6 +1,7 @@
 name: This Weeks Events
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 8 * * MON'
 


### PR DESCRIPTION
We wanted to trigger the event manually to check it worked as expected. So adding a `workflow_dispatch` to allow that 🥇 