### PR TITLE
Making github actions version number less specific

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,11 +14,11 @@ jobs:
     - uses: actions/checkout@master
       with:
         ref: 'main'
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby 2.7
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
-    - uses: actions/cache@v2.1.2
+        ruby-version: 2.7
+    - uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-changelog-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/hourly-meeting-check.yml
+++ b/.github/workflows/hourly-meeting-check.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         ruby-version: 2.7
     - name: Cache gems
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Cache gems
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-ruby-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         ruby-version: 2.7
     - name: Cache gems
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/this-weeks-events.yml
+++ b/.github/workflows/this-weeks-events.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         ruby-version: 2.7
     - name: Cache gems
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
PRs like https://github.com/Virtual-Coffee/Virtual-Coffee-Bot/pull/9 could get annoying, so I'm making them only the major versions. 