### PR TITLE
Pushing back reminders by 5 minutes

### DIFF
--- a/.github/workflows/hourly-meeting-check.yml
+++ b/.github/workflows/hourly-meeting-check.yml
@@ -2,7 +2,7 @@ name: Hourly Events Check
 
 on:
   schedule:
-    - cron:  '50 * * * *'
+    - cron:  '45 * * * *'
 
 jobs:
   hourly_events_check:


### PR DESCRIPTION
The reminders are running with a ~7 minute delay on average, it looks like the GitHub Actions don't quite run on the exact scheduled time we expect them to 😅

Just incase the delay goes >10 minutes, I think it could be good to push it back 5 minutes.