### PR TITLE
Run the hourly meeting check at Half Past

### DIFF
--- a/.github/workflows/hourly-meeting-check.yml
+++ b/.github/workflows/hourly-meeting-check.yml
@@ -2,7 +2,7 @@ name: Hourly Events Check
 
 on:
   schedule:
-    - cron:  '45 * * * *'
+    - cron:  '30 * * * *'
 
 jobs:
   hourly_events_check:


### PR DESCRIPTION
It appears GitHub Actions can be delayed by up to 15 minutes. So scheduling them even more back.