### PR TITLE
Enabling RSpec & Rubocop flows on PRs

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,6 +3,7 @@ name: Testing
 
 on:
   push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,7 @@
 name: RuboCop
 
 on:
+  pull_request:
   push:
     branches-ignore:
       - main


### PR DESCRIPTION
I noticed the workflows wearn't triggering on https://github.com/Virtual-Coffee/Virtual-Coffee-Bot/pull/21 

I think it's due to it's missing `on: [:pull_request]` in the YAML configuration.