### PR TITLE
Fix: NameError: undefined method `xmlschema' for class `Time'

### DIFF
--- a/lib/virtual_coffee_bot.rb
+++ b/lib/virtual_coffee_bot.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
-Bundler.require :default, (ENV['RACK_ENV'] || 'development').to_sym
-
 require 'bundler'
+Bundler.require :default, (ENV['RACK_ENV'] || 'development').to_sym
 Bundler.setup
+
 require 'zeitwerk'
 require 'active_support/core_ext'
 


### PR DESCRIPTION
```
NameError: undefined method `xmlschema' for class `Time'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext/time/conversions.rb:72:in `alias_method'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext/time/conversions.rb:72:in `<class:Time>'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext/time/conversions.rb:6:in `<top (required)>'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext/date_time/conversions.rb:5:in `require'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext/date_time/conversions.rb:5:in `<top (required)>'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext/date_time.rb:7:in `require'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext/date_time.rb:7:in `<top (required)>'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext.rb:4:in `require'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext.rb:4:in `block in <top (required)>'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext.rb:3:in `each'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext.rb:3:in `<top (required)>'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/dotiw-5.2.0/lib/dotiw.rb:6:in `require'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/dotiw-5.2.0/lib/dotiw.rb:6:in `<top (required)>'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/lib/virtual_coffee_bot.rb:2:in `<top (required)>'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/Rakefile:5:in `require'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/Rakefile:5:in `block in <top (required)>'
/home/runner/work/Virtual-Coffee-Bot/Virtual-Coffee-Bot/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/opt/hostedtoolcache/Ruby/2.7.2/x64/bin/bundle:23:in `load'
/opt/hostedtoolcache/Ruby/2.7.2/x64/bin/bundle:23:in `<main>'
Tasks: TOP => virtual_coffee_bot:todays_events => environment
```

It looks like upgrading the gems earlier this week broke something 😅 I reran this locally with a small tweak and it seemed to work, so 🤞.