### PR TITLE
Attemping to fix the undefined method `xmlschema' for class `Time'`

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,9 +21,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-changelog-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-changelog-
+        key: ${{ runner.os }}-changelog
     - name: Create local changes
       run: |
         gem install github_changelog_generator

--- a/.github/workflows/daily-meeting-check.yml
+++ b/.github/workflows/daily-meeting-check.yml
@@ -11,23 +11,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 2.7.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 2.7.2
     - name: Cache gems
       uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-
     - name: Install gems
       run: |
         bundle config path vendor/bundle
-        gem install bundler
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundle install --jobs 4 --retry 3 --without development test
     - name: Run Report
       env:
         SLACK_CHANNEL: "#announcements"

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-ruby-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-rspec-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
     - name: Install Gems
       env:
         RAILS_ENV: test

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -24,8 +24,6 @@ jobs:
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-ruby-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-ruby-${{ matrix.ruby }}
     - name: Install Gems
       env:
         RAILS_ENV: test

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -21,8 +21,6 @@ jobs:
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-rubocop-
     - name: Install gems
       run: |
         bundle config path vendor/bundle

--- a/.github/workflows/this-weeks-events.yml
+++ b/.github/workflows/this-weeks-events.yml
@@ -11,23 +11,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 2.7.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 2.7.2
     - name: Cache gems
       uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-
     - name: Install gems
       run: |
         bundle config path vendor/bundle
-        gem install bundler
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundle install --jobs 4 --retry 3 --without development test
     - name: Run Report
       env:
         SLACK_CHANNEL: "#announcements"

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,18 @@
+source 'https://rubygems.org'
 ruby File.read('.ruby-version').chomp
 
-source 'https://rubygems.org' do
-  gem 'activesupport'
-  gem 'dotenv'
-  gem 'dotiw'
-  gem 'rake'
-  gem 'slack-ruby-bot'
-  gem 'zeitwerk'
+gem 'activesupport'
+gem 'dotenv'
+gem 'dotiw'
+gem 'rake'
+gem 'slack-ruby-bot'
+gem 'zeitwerk'
 
-  group :development, :test do
-    gem 'rack-test'
-    gem 'rspec'
-    gem 'simplecov', require: false
-    gem 'timecop'
-    gem 'vcr'
-    gem 'webmock'
-  end
+group :test do
+  gem 'rack-test'
+  gem 'rspec'
+  gem 'simplecov', require: false
+  gem 'timecop'
+  gem 'vcr'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,18 +81,18 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport!
-  dotenv!
-  dotiw!
-  rack-test!
-  rake!
-  rspec!
-  simplecov!
-  slack-ruby-bot!
-  timecop!
-  vcr!
-  webmock!
-  zeitwerk!
+  activesupport
+  dotenv
+  dotiw
+  rack-test
+  rake
+  rspec
+  simplecov
+  slack-ruby-bot
+  timecop
+  vcr
+  webmock
+  zeitwerk
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/lib/meeting_place/events.rb
+++ b/lib/meeting_place/events.rb
@@ -1,4 +1,6 @@
 # Used to pull all the events from MeetingPlace.
+require 'net/http'
+
 module MeetingPlace
   class Events
     def initialize(group)

--- a/lib/virtual_coffee_bot.rb
+++ b/lib/virtual_coffee_bot.rb
@@ -1,10 +1,9 @@
 require 'rubygems'
 require 'bundler'
-Bundler.require :default, (ENV['RACK_ENV'] || 'development').to_sym
-Bundler.setup
+require 'bundler/setup'
 
+require 'active_support/core_ext/time'
 require 'zeitwerk'
-require 'active_support/core_ext'
 
 loader = Zeitwerk::Loader.new
 loader.push_dir(__dir__)


### PR DESCRIPTION
I'm still seeing `NameError: undefined method `xmlschema' for class `Time'` error :/

Turns out, might have been cached by GitHub Actions caching an older version of a gem & restoring it. Causing *super weirdness* to ocour.