### PR TITLE
Tidying GitHub Actions to run on push (and run faster)

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,27 +3,18 @@ name: Testing
 
 on:
   push:
-  pull_request:
 
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: [2.7]
     runs-on: ubuntu-latest
-    name: Test against Ruby ${{ matrix.ruby }}
+    name: Test against Ruby 2.7
 
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
-    - name: Cache gems
-      uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-rspec-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
+        ruby-version: 2.7
+        bundle: true
     - name: Install Gems
       env:
         RAILS_ENV: test

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,7 +1,6 @@
 name: RuboCop
 
 on:
-  pull_request:
   push:
     branches-ignore:
       - main


### PR DESCRIPTION
I've been messing GitHub actions a lot recently & levelled up a bunch! I figured out we can just run on `push` for these workflows, plus we `setup/ruby` has a built in cache now :D