### PR TITLE
Making next event alert use the alarm emoji

### DIFF
--- a/lib/virtual_coffee_bot/reports/next_event.rb
+++ b/lib/virtual_coffee_bot/reports/next_event.rb
@@ -8,7 +8,7 @@ module VirtualCoffeeBot
 
       def text
         [
-          "📅 *Next Event:* #{next_event.name}",
+          "⏰ *Next Event:* #{next_event.name}",
           "Starting in #{next_event.time_to_start} | <#{next_event.url}|View Details>"
         ].join("\n\n")
       end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/325384/110684243-d1552480-81d4-11eb-92d6-b2dc7bb6585e.png)

Slack has [keyword notifications](https://slack.com/intl/en-gb/help/articles/201355156-Configure-your-Slack-notifications#keyword-notifications), so we want to make a uniquer reference for when events are starting.