### PR TITLE
fix: Correcting reference to repo in changelog generator

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,7 +20,7 @@ jobs:
         bundler-cache: true
     - name: Create local changes
       run: |
-        bundle exec github_changelog_generator -u Virtual-Coffee -p Virtual-Coffee-Bot --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        bundle exec github_changelog_generator -u Virtual-Coffee -p bot-meetingplace-events --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"


### PR DESCRIPTION
We renamed the repo a few weeks back, and I didn't update the changelog
generator. Ideally I'd like to have it pull from its own environment, but I've not cracked how to handle that yet.